### PR TITLE
Enabled support for sending binary messages via ng-websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,33 @@ angular.module('MyCoolChainedWebApp', ['ngWebsocket'])
           });
     });
 ```
+Want to send a binary message?  Set the 'binary' parameter to true.
+
+```javascript
+'use strict';
+
+angular.module('MyCoolChainedWebApp', ['ngWebsocket'])
+    .run(function ($websocket) {
+        var ws = $websocket.$new('ws://localhost:12345')
+          .$on('$open', function () {
+            console.log('Oh my gosh, websocket is really open! Fukken awesome!');
+
+            var data = new Uint8Array([21,31]);
+
+            ws.$emit('ping', 'hi listening websocket server') // send a message to the websocket server
+              .$emit('pong', data, true);
+          })
+          .$on('pong', function (data) {
+            console.log('The websocket server has sent the following data:');
+            console.log(data);
+
+            ws.$close();
+          })
+          .$on('$close', function () {
+            console.log('Noooooooooou, I want to have more fun with ngWebsocket, damn it!');
+          });
+    });
+```
 
 Your back-end team is lazy? No problem: we can do it on our own!
 

--- a/README.md
+++ b/README.md
@@ -196,12 +196,19 @@ angular.module('MyCoolChainedWebApp', ['ngWebsocket'])
 
             var data = new Uint8Array([21,31]);
 
+            ws.binaryType = 'arraybuffer';
+
             ws.$emit('ping', 'hi listening websocket server') // send a message to the websocket server
               .$emit('pong', data, true);
           })
           .$on('pong', function (data) {
             console.log('The websocket server has sent the following data:');
-            console.log(data);
+
+            if (data instanceof ArrayBuffer) {
+                console.log('A binary message of length', data.toArrayBuffer().byteLength;
+            } else {
+                console.log(data);
+            }
 
             ws.$close();
           })

--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -214,20 +214,34 @@
             return me;
         };
 
-        me.$$send = function (message) {
-            if (me.$ready()) me.$$ws.send(JSON.stringify(message));
-            else if (me.$$config.enqueue) me.$$queue.push(message);
+        me.$$send = function (message, binary) {
+            if (me.$ready()) {
+                if (binary === undefined || !binary) {
+                    me.$$ws.send(JSON.stringify(message));
+                } else {
+                    me.$$ws.send(message);
+                }
+            }
+            else if (me.$$config.enqueue) {
+                me.$$queue.push(message);
+            }
         };
 
-        me.$emit = function (event, data) {
+        me.$emit = function (event, data, binary) {
             if (typeof event !== 'string') throw new Error('$emit needs two parameter: a String and a Object or a String');
 
-            var message = {
-                event: event,
-                data: data
-            };
+            if (binary === undefined || !binary) {
 
-            me.$$send(message);
+                var message = {
+                    event: event,
+                    data: data
+                };
+
+                me.$$send(message);
+            } else {
+                // do not compose JSON message, send 'data' as-is
+                me.$$send(data, binary);
+            }
 
             return me;
         };


### PR DESCRIPTION
Realized after some confusion that there existed no way to send a binary message (ArrayBuffer or Blob) via ng-websocket.

Therefore, forked and added a 'binary' flag to the $emit and $$send functions.  If 'binary' is false, default behavior will be used.

Maintained the enqueue fucntionality.