### PR TITLE
Allow creation of new websocket, even if one exists already (forceNew)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ng-websocket
     - [Auto Reconnection](#reconnect)
     - [Enqueue Unsent Messages](#enqueue)
     - [Mock Websocket Server](#mock)
+    - [Force New Connection](#force-new)
   - [Testing](#testing)
   - [API](#api)
     - [$websocketProvider](#websocketProvider)

--- a/README.md
+++ b/README.md
@@ -502,6 +502,18 @@ angular.run(function ($websocket) {
 ```
 
 A new instance is returned and the internal WebSocket has already started the connection with the websocket server on the backend.
+By default, once created connections will be reused. If you want to force the creation of a new connection, use forceNewConnection:
+
+```javascript
+angular.run(function ($websocket) {
+    var ws = $websocket.$new({
+        url: 'ws://localhost:12345'),
+        forceNewConnection: true
+    });
+});
+```
+
+Bear in mind that the previous websocket will not close, so be careful with this parameter.
 
 **object**
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ angular.run(function ($websocket) {
 Bear in mind that this will open a new connection to the same websocket, no matter if one exists already. Make sure to close
 your old websocket correctly and timely.
 
-** Default: false **
+**Default: false**
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Following the explanation of the configuration object - {Type} PropertyName (def
   - **{Boolean} enqueue (false)**: enqueue unsent messages. By default, a websocket discards messages when the connection is closed (false) but it can enqueue them and send afterwards the connection gets open back (true). For more information see [Features - Enqueue Unsent Messages](#enqueue)
   - **{Boolean/Object} mock (false)**: mock a websocket server. By default, a websocket run only if the webserver socket is listening (false) but it can be useful to mock the backend to make the websocket working (true). For more information see [Features - Mock Websocket Server](#mock)
   - **{String/String[]} (null)**: Either a single protocol string or an array of protocol strings. This is the same as the WebSocket protocols argument.
-  - **{Boolean} forceNew (false)**: force creation of new connection. By default, a websocket is reused on [$websocket.$new](#new). For more information see [Features - Force New](#force)
+  - **{Boolean} forceNew (false)**: force creation of new connection. By default, a websocket is reused on [$websocket.$new](#new). For more information see [Features - Force New](#force-new)
 
 ### Constants
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,26 @@ angular.run(function ($websocket) {
 
 **Default: disabled**
 
+## Force New
+
+In some cases you may not want to reuse an existing websocket connection and need to create a new one.
+By default, creating a new websocket with the same url will try to reuse a before created websocket connection, even if it is closed.
+You can force a new connection using this flag.
+
+```javascript
+angular.run(function ($websocket) {
+    var ws = $websocket.$new({
+        url: 'ws://localhost:12345',
+        forceNew: true
+    });
+});
+```
+
+Bear in mind that this will open a new connection to the same websocket, no matter if one exists already. Make sure to close
+your old websocket correctly and timely.
+
+** Default: false **
+
 # Testing
 
 This module uses [Karma](http://karma-runner.github.io/0.12/index.html) with [Jasmine](http://jasmine.github.io/) for unit testing, so before launching any test check out if all dependencies are correctly installed:
@@ -502,18 +522,6 @@ angular.run(function ($websocket) {
 ```
 
 A new instance is returned and the internal WebSocket has already started the connection with the websocket server on the backend.
-By default, once created connections will be reused. If you want to force the creation of a new connection, use forceNewConnection:
-
-```javascript
-angular.run(function ($websocket) {
-    var ws = $websocket.$new({
-        url: 'ws://localhost:12345'),
-        forceNewConnection: true
-    });
-});
-```
-
-Bear in mind that the previous websocket will not close, so be careful with this parameter.
 
 **object**
 
@@ -527,7 +535,8 @@ angular.run(function ($websocket) {
         reconnect: true,
         reconnectInterval: 2000,
         mock: false,
-        enqueue: false
+        enqueue: false,
+        forceNew: false
     );
 });
 ```
@@ -592,7 +601,8 @@ angular.run(function ($websocket) {
         reconnectInterval: 2000,
         enqueue: false,
         mock: false,
-        protocols: ['binary', 'base64']
+        protocols: ['binary', 'base64'],
+        forceNew: false
     });
 });
 ```
@@ -605,6 +615,7 @@ Following the explanation of the configuration object - {Type} PropertyName (def
   - **{Boolean} enqueue (false)**: enqueue unsent messages. By default, a websocket discards messages when the connection is closed (false) but it can enqueue them and send afterwards the connection gets open back (true). For more information see [Features - Enqueue Unsent Messages](#enqueue)
   - **{Boolean/Object} mock (false)**: mock a websocket server. By default, a websocket run only if the webserver socket is listening (false) but it can be useful to mock the backend to make the websocket working (true). For more information see [Features - Mock Websocket Server](#mock)
   - **{String/String[]} (null)**: Either a single protocol string or an array of protocol strings. This is the same as the WebSocket protocols argument.
+  - **{Boolean} forceNew (false)**: force creation of new connection. By default, a websocket is reused on [$websocket.$new](#new). For more information see [Features - Force New](#force)
 
 ### Constants
 

--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -17,7 +17,8 @@
             reconnectInterval: 2000,
             mock: false,
             enqueue: false,
-            protocols: null
+            protocols: null,
+            forceNew: false
         };
 
         wsp.$setup = function (cfg) {
@@ -65,15 +66,10 @@
                     if (typeof arguments[1] === 'string' && arguments[1].length > 0) cfg.protocols = [arguments[1]];
                     else if (typeof arguments[1] === 'object' && arguments[1].length > 0) cfg.protocols = arguments[1];
                 }
-            } else if(typeof cfg === 'object') {
-                if (cfg.forceNewConnection) {
-                    wss.$remove(cfg.url);
-                }
+            }
 
-                cfg = {
-                    url: cfg.url,
-                    forceNewConnection: cfg.forceNewConnection ? cfg.forceNewConnection : false
-                };
+            if (cfg.forceNew) {
+                wss.$remove(cfg.url);
             }
 
             // If the websocket already exists, return that instance

--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -49,6 +49,10 @@
             return wss.$$websocketList[url];
         };
 
+        wss.$remove = function (url) {
+            delete wss.$$websocketList[url];
+        };
+
         wss.$new = function (cfg) {
             cfg = cfg || {};
 
@@ -61,6 +65,15 @@
                     if (typeof arguments[1] === 'string' && arguments[1].length > 0) cfg.protocols = [arguments[1]];
                     else if (typeof arguments[1] === 'object' && arguments[1].length > 0) cfg.protocols = arguments[1];
                 }
+            } else if(typeof cfg === 'object') {
+                if (cfg.forceNewConnection) {
+                    wss.$remove(cfg.url);
+                }
+
+                cfg = {
+                    url: cfg.url,
+                    forceNewConnection: cfg.forceNewConnection ? cfg.forceNewConnection : false
+                };
             }
 
             // If the websocket already exists, return that instance

--- a/test/unit/ng-websocket-service-spec.js
+++ b/test/unit/ng-websocket-service-spec.js
@@ -13,6 +13,9 @@ describe('Testing ng-websocket-service', function () {
             expect($websocket.$new).toBeDefined();
             expect($websocket.$get).toBeDefined();
         });
+		it('should have $remove method', function(){
+			expect($websocket.$remove).toBeDefined();
+		});
     });
 
     describe('Testing $new operator', function () {
@@ -82,5 +85,20 @@ describe('Testing ng-websocket-service', function () {
 
             expect(wsObj).not.toEqual(ws);
         });
+
+		it('should return a new ng-websocket instance for forceNew', function(){
+			var url = 'ws://localhost:12345';
+			var ws1 = $websocket.$new({
+				url: url
+			});
+
+			var ws2 = $websocket.$new({
+				url: url,
+				forceNew: true
+			});
+
+			expect(ws1).not.toEqual(ws2);	
+		});
     });
+
 });


### PR DESCRIPTION
Hi, Me and a few colleagues of mine are working on a project and are using ngWebsocket in it. We had some trouble to refresh a websocket connection and had the case where we had to re-initialize it completely. Since this wasn't yet possible with ngWebsocket, I added this extra flag (forceNew) to return a new connection on demand, no matter if it was created before. It would be awesome, if you could include my change into the newest version. Regards, Ivan.