### PR TITLE
Remove closed websockets from websocket cache.

### DIFF
--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -250,6 +250,8 @@
         };
 
         me.$close = function () {
+            removeFromCache();
+
             if (me.$status() !== me.$CLOSED) me.$$ws.close();
 
             if (me.$$reconnectTask) {

--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -68,7 +68,10 @@
             if (typeof ws === 'undefined') {
                 var wsCfg = angular.extend({}, wss.$$config, cfg);
 
-                ws = new $websocket(wsCfg, $http);
+                ws = new $websocket(wsCfg, $http, function() {
+                	delete wss.$$websocketList[wsCfg.url];
+                });
+
                 wss.$$websocketList[wsCfg.url] = ws;
             }
 
@@ -83,10 +86,13 @@
      * @description
      * HTML5 Websocket wrapper class for AngularJS
      */
-    function $websocket (cfg, $http) {
+    function $websocket (cfg, $http, removeFromCache) {
         var me = this;
 
-        if (typeof cfg === 'undefined' || (typeof cfg === 'object' && typeof cfg.url === 'undefined')) throw new Error('An url must be specified for WebSocket');
+        if (typeof cfg === 'undefined' || (typeof cfg === 'object' && typeof cfg.url === 'undefined')) {
+        	removeFromCache();
+        	throw new Error('An url must be specified for WebSocket');
+        }
 
         me.$$eventMap = {};
         me.$$ws = undefined;
@@ -169,6 +175,8 @@
                     me.$$reconnectTask = setInterval(function () {
                         if (me.$status() === me.$CLOSED) me.$open();
                     }, me.$$config.reconnectInterval);
+                } else {
+                	removeFromCache();
                 }
 
                 me.$$fireEvent('$close');

--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -89,6 +89,8 @@
     function $websocket (cfg, $http, removeFromCache) {
         var me = this;
 
+        removeFromCache = removeFromCache || function() {};
+
         if (typeof cfg === 'undefined' || (typeof cfg === 'object' && typeof cfg.url === 'undefined')) {
         	removeFromCache();
         	throw new Error('An url must be specified for WebSocket');


### PR DESCRIPTION
I had a similar problem to https://github.com/wilk/ng-websocket/pull/21/files. After closing a websocket and reopening it later on I only got closed websockets.
My expectation was that I get a new websocket when calling $new and not a cached and already closed one.
