### PR TITLE
$un() now has an optional handler parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ The above websocket has not listener attached at the end of the execution.
 **Usage**
 
 ```javascript
-$un(event)
+$un(event, [handler])
 ```
 
 **Arguments**
@@ -686,6 +686,8 @@ $un(event)
 | **Param** | **Type** | **Details** |
 | --------- | -------- | ----------- |
 | event     | String   | the event to detach the listener |
+| handler (optional) | Function | a specific handler to detach |
+
 
 **Returns**
 

--- a/ng-websocket.js
+++ b/ng-websocket.js
@@ -197,11 +197,16 @@
             return me;
         };
 
-        me.$un = function (event) {
+        me.$un = function (event, handler) {
             if (typeof event !== 'string') throw new Error('$un needs a String representing an event.');
 
-            if (typeof me.$$eventMap[event] !== 'undefined') delete me.$$eventMap[event];
-
+            if (typeof me.$$eventMap[event] !== 'undefined') {
+                if (typeof handler == 'undefined') delete me.$$eventMap[event];
+                var pos = me.$$eventMap[event].indexOf(handler);
+                if (pos > -1) {
+                    me.$$eventMap[event].splice(pos, 1);
+                }
+            }
             return me;
         };
 


### PR DESCRIPTION
with this patch, $un(event, handler) removes a specific event handler, leaving other handlers undisturbed.

Background:

Building a mid-size Angular app, using ng-websocket with a very thin wrapper service. Our WS service has channels you subscribe to by sending `sub this`, `sub that`, as well as `unsub this`.

Different controllers subscribe to different channels. Some overlap in the channels they subscribe to, or may overlap in the future.

When the user changes away from a view, we want the controllers to unload completely, to avoid memleaks. So we carefully unsubscribe. However, we want to avoid unsubscribing the event.

This patch saves us from running our own eventMap, and seems to have general value.
